### PR TITLE
Handle Klat persona update events

### DIFF
--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -155,13 +155,13 @@ class LLMBot(ChatBot):
         :returns response data from LLM API
         """
         queue = self.mq_queue_config.ask_discusser_queue
-        request_data = LLMDiscussRequest(model=self.base_llm,
-                                         persona=self.persona,
-                                         query=prompt,
-                                         options=options,
-                                         history=[],
-                                         message_id="")
         try:
+            request_data = LLMDiscussRequest(model=self.base_llm,
+                                             persona=self.persona,
+                                             query=prompt,
+                                             options=options,
+                                             history=[],
+                                             message_id="")
             resp_data = send_mq_request(vhost=self.mq_queue_config.vhost,
                                         request_data=request_data.model_dump(),
                                         target_queue=queue,

--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -130,8 +130,10 @@ class LLMBot(ChatBot):
         :returns response from LLM API
         """
         queue = self.mq_queue_config.ask_response_queue
-        LOG.info(f"Sending to {self.mq_queue_config.vhost}/{queue}")
+
         try:
+            LOG.info(f"Sending to {self.mq_queue_config.vhost}/{queue}")
+
             request_data = LLMProposeRequest(model=self.base_llm,
                                              persona=self.persona,
                                              query=shout,
@@ -141,13 +143,12 @@ class LLMBot(ChatBot):
                                         request_data=request_data.model_dump(),
                                         target_queue=queue,
                                         response_queue=f"{queue}.response")
-            return LLMProposeResponse(**resp_data)
+            return LLMProposeResponse.model_validate(resp_data)
         except Exception as e:
             LOG.exception(f"Failed to get response on "
                           f"{self.mq_queue_config.vhost}/{queue}: {e}")
 
-    def _get_llm_api_opinion(self, prompt: str,
-                             options: dict) -> Optional[LLMDiscussResponse]:
+    def _get_llm_api_opinion(self, prompt: str, options: dict) -> Optional[LLMDiscussResponse]:
         """
         Requests LLM API for discussion of provided submind responses
         :param prompt: incoming prompt text
@@ -155,7 +156,10 @@ class LLMBot(ChatBot):
         :returns response data from LLM API
         """
         queue = self.mq_queue_config.ask_discusser_queue
+
         try:
+            LOG.info(f"Sending to {self.mq_queue_config.vhost}/{queue}")
+
             request_data = LLMDiscussRequest(model=self.base_llm,
                                              persona=self.persona,
                                              query=prompt,
@@ -166,14 +170,10 @@ class LLMBot(ChatBot):
                                         request_data=request_data.model_dump(),
                                         target_queue=queue,
                                         response_queue=f"{queue}.response")
+            return LLMDiscussResponse.model_validate(obj=resp_data)
         except Exception as e:
             LOG.exception(f"Failed to get response on "
                           f"{self.mq_queue_config.vhost}/{queue}: {e}")
-            return
-        try:
-            return LLMDiscussResponse.model_validate(obj=resp_data)
-        except ValidationError as e:
-            LOG.exception(f"Failed to validate response_data={resp_data} with LLMDiscussResponse:{e}")
 
     def _get_llm_api_choice(self, prompt: str,
                             responses: List[str]) -> Optional[LLMVoteResponse]:
@@ -186,6 +186,8 @@ class LLMBot(ChatBot):
         queue = self.mq_queue_config.ask_appraiser_queue
 
         try:
+            LOG.info(f"Sending to {self.mq_queue_config.vhost}/{queue}")
+
             request_data = LLMVoteRequest(model=self.base_llm,
                                           persona=self.persona,
                                           query=prompt,
@@ -196,7 +198,7 @@ class LLMBot(ChatBot):
                                         request_data=request_data.model_dump(),
                                         target_queue=queue,
                                         response_queue=f"{queue}.response")
-            return LLMVoteResponse(**resp_data)
+            return LLMVoteResponse.model_validate(obj=resp_data)
         except Exception as e:
             LOG.exception(f"Failed to get response on "
                           f"{self.mq_queue_config.vhost}/{queue}: {e}")

--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -37,7 +37,6 @@ from neon_data_models.models.api.mq import (
 from neon_mq_connector.utils.client_utils import send_mq_request
 from neon_utils.logger import LOG
 from neon_data_models.models.api.llm import LLMPersona
-from pydantic import ValidationError
 
 from neon_llm_core.utils.config import LLMMQConfig
 from neon_llm_core.utils.constants import DEFAULT_RESPONSE, DEFAULT_VOTE

--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -26,9 +26,14 @@
 
 from typing import List, Optional
 from chatbot_core.v2 import ChatBot
-from neon_data_models.models.api.mq import (LLMProposeRequest,
-                                            LLMDiscussRequest, LLMVoteRequest, LLMProposeResponse, LLMDiscussResponse,
-                                            LLMVoteResponse)
+from neon_data_models.models.api.mq import (
+    LLMProposeRequest,
+    LLMDiscussRequest,
+    LLMVoteRequest,
+    LLMProposeResponse,
+    LLMDiscussResponse,
+    LLMVoteResponse,
+)
 from neon_mq_connector.utils.client_utils import send_mq_request
 from neon_utils.logger import LOG
 from neon_data_models.models.api.llm import LLMPersona

--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -109,7 +109,7 @@ class LLMBot(ChatBot):
         options = {k: v for k, v in options.items()
                    if k != self.service_name}
 
-        if options:
+        if prompt_sentence and options:
             bots = list(options)
             bot_responses = list(options.values())
             LOG.info(f'bots={bots}, answers={bot_responses}')

--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -142,7 +142,7 @@ class LLMBot(ChatBot):
                                         request_data=request_data.model_dump(),
                                         target_queue=queue,
                                         response_queue=f"{queue}.response")
-            return LLMProposeResponse.model_validate(resp_data)
+            return LLMProposeResponse.model_validate(obj=resp_data)
         except Exception as e:
             LOG.exception(f"Failed to get response on "
                           f"{self.mq_queue_config.vhost}/{queue}: {e}")

--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -33,8 +33,11 @@ from neon_mq_connector.connector import MQConnector
 from neon_mq_connector.utils.rabbit_utils import create_mq_callback
 from neon_utils.logger import LOG
 
-from neon_data_models.models.api.mq import (LLMProposeResponse,
-                                            LLMDiscussResponse, LLMVoteResponse)
+from neon_data_models.models.api.mq import (
+    LLMProposeResponse,
+    LLMDiscussResponse,
+    LLMVoteResponse,
+)
 
 from neon_llm_core.utils.config import load_config
 from neon_llm_core.llm import NeonLLM

--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -154,7 +154,6 @@ class NeonLLMMQConnector(MQConnector, ABC):
         :param body: MQ message body containing persona data for update
         """
         with self._persona_update_lock:
-            self._personas_provider.stop_default_personas()
             self._personas_provider.apply_incoming_persona_data(body)
 
     @create_mq_callback()

--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -154,7 +154,7 @@ class NeonLLMMQConnector(MQConnector, ABC):
         :param body: MQ message body containing persona data for update
         """
         with self._persona_update_lock:
-            self._personas_provider.apply_incoming_persona_data(body)
+            self._personas_provider.apply_incoming_persona(body)
 
     @create_mq_callback()
     def handle_persona_delete(self, body: dict):

--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -154,7 +154,7 @@ class NeonLLMMQConnector(MQConnector, ABC):
         :param body: MQ message body containing persona data for update
         """
         with self._persona_update_lock:
-            self._personas_provider.apply_incoming_persona(body)
+            self._personas_provider.apply_persona_data(persona_data=body)
 
     @create_mq_callback()
     def handle_persona_delete(self, body: dict):

--- a/neon_llm_core/utils/personas/provider.py
+++ b/neon_llm_core/utils/personas/provider.py
@@ -183,7 +183,7 @@ class PersonasProvider:
             # Once first manually configured persona added - pruning default personas
             if self._persona_handlers_state.default_personas_running:
                 LOG.info("Cleaning up default personas")
-                self._persona_handlers_state.clean_up_personas(ignore_items=[persona.id])
+                self._persona_handlers_state.clean_up_personas(ignore_items=[persona])
                 self._persona_handlers_state.default_personas_running = False
 
         # May occur if the last updated persona was set to be disabled

--- a/neon_llm_core/utils/personas/provider.py
+++ b/neon_llm_core/utils/personas/provider.py
@@ -182,9 +182,10 @@ class PersonasProvider:
 
             # Once first manually configured persona added - pruning default personas
             if self._persona_handlers_state.default_personas_running:
-                LOG.info("Cleaning up default personas")
+                LOG.info("Removing default personas")
                 self._persona_handlers_state.clean_up_personas(ignore_items=[persona])
                 self._persona_handlers_state.default_personas_running = False
+                LOG.info("Removed default personas")
 
         # May occur if the last updated persona was set to be disabled
         if not self._persona_handlers_state.has_connected_personas():

--- a/neon_llm_core/utils/personas/state.py
+++ b/neon_llm_core/utils/personas/state.py
@@ -87,7 +87,7 @@ class PersonaHandlersState:
         persona_dict = persona.model_dump()
         if persona.id in list(self._created_items):
             if self._created_items[persona.id].persona != persona_dict:
-                LOG.warning(f"Recreating persona: '{persona.id}' with new data={persona}")
+                LOG.info(f"Received new data for persona: '{persona.id}' - removing old instance")
                 self.remove_persona(persona_id=persona.id)
             else:
                 LOG.debug('Persona config provided is identical to existing, skipping')

--- a/neon_llm_core/utils/personas/state.py
+++ b/neon_llm_core/utils/personas/state.py
@@ -55,6 +55,10 @@ class PersonaHandlersState:
     def default_personas(self):
         return self.ovos_config.get("llm_bots", {}).get(self.service_name, [])
 
+    @property
+    def connected_persona_ids(self) -> List[str]:
+        return list(self._created_items)
+
     def has_connected_personas(self) -> bool:
         return bool(self._created_items)
 
@@ -72,7 +76,7 @@ class PersonaHandlersState:
             self.default_personas_running = True
         else:
             if self.default_personas_running:
-                LOG.info('Default personas already running')
+                LOG.debug('Default personas already running')
             elif not self.default_personas:
                 LOG.warning('Default personas not configured')
 

--- a/neon_llm_core/utils/personas/state.py
+++ b/neon_llm_core/utils/personas/state.py
@@ -31,10 +31,9 @@ from functools import cached_property
 from threading import Lock
 from typing import Dict, List, Optional
 
+from neon_data_models.models.api.llm import LLMPersona
 from neon_utils.logger import LOG
-
 from neon_llm_core.chatbot import LLMBot
-from neon_llm_core.utils.personas.models import PersonaModel
 
 
 class PersonaHandlersState:
@@ -69,11 +68,11 @@ class PersonaHandlersState:
             LOG.info(f"Initializing default personas for: {self.service_name}")
             for persona in self.default_personas:
                 self.add_persona_handler(
-                    persona=PersonaModel.model_validate(obj=persona)
+                    persona=LLMPersona.model_validate(obj=persona)
                 )
             self.default_personas_running = True
 
-    def add_persona_handler(self, persona: PersonaModel) -> Optional[LLMBot]:
+    def add_persona_handler(self, persona: LLMPersona) -> Optional[LLMBot]:
         """
         Creates an `LLMBot` instance for the given persona if the persona does
         not yet exist AND the persona is not disabled in configuration.
@@ -109,7 +108,7 @@ class PersonaHandlersState:
         self._created_items[persona.id] = bot
         return bot
 
-    def clean_up_personas(self, ignore_items: List[PersonaModel] = None):
+    def clean_up_personas(self, ignore_items: List[LLMPersona] = None):
         with self.personas_clean_up_lock:
             connected_personas = set(self._created_items)
             ignored_persona_ids = set(persona.id for persona in ignore_items or [])

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,4 +3,4 @@ neon-mq-connector>=0.7.2a17
 neon_utils[sentry]~=1.12
 ovos-config~=0.0,>=0.0.10
 pydantic~=2.6
-neon-data-models>=0.0.0a5
+neon-data-models>=0.0.0a7

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,4 +3,4 @@ neon-mq-connector>=0.7.2a17
 neon_utils[sentry]~=1.12
 ovos-config~=0.0,>=0.0.10
 pydantic~=2.6
-neon-data-models>=0.0.0a7
+neon-data-models>=0.0.0a8

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -27,9 +27,15 @@ from datetime import datetime
 from unittest import TestCase
 from unittest.mock import patch
 
-from neon_data_models.models.api import LLMPersona, LLMProposeRequest, \
-    LLMProposeResponse, LLMDiscussRequest, LLMDiscussResponse, LLMVoteRequest, \
-    LLMVoteResponse
+from neon_data_models.models.api import (
+    LLMPersona,
+    LLMProposeRequest,
+    LLMProposeResponse,
+    LLMDiscussRequest,
+    LLMDiscussResponse,
+    LLMVoteRequest,
+    LLMVoteResponse,
+)
 
 from neon_llm_core.chatbot import LLMBot
 from neon_llm_core.utils.config import LLMMQConfig

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -1,0 +1,25 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 NeonGecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/test_utils/test_provider.py
+++ b/tests/test_utils/test_provider.py
@@ -1,0 +1,148 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 NeonGecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+from unittest.mock import patch, Mock, MagicMock
+
+from neon_llm_core.utils.personas.provider import PersonasProvider
+from neon_llm_core.utils.personas.state import PersonaHandlersState
+
+from .utils.factory import PersonaFactory
+
+
+class TestPersonasProvider(unittest.TestCase):
+
+    def setUp(self):
+        """Set up the test environment and mock dependencies."""
+        self.mock_service_name = "mock_service"
+        self.mock_config = {
+            "llm_bots": {
+                self.mock_service_name: [PersonaFactory.create_mock_llm_persona(enabled=True) for _ in range(5)]
+            },
+            "MQ": {"users": {"neon_llm_submind": {"user": "test", "password": "test"}}}
+        }
+        self.provider = PersonasProvider(service_name=self.mock_service_name, ovos_config=self.mock_config)
+
+    @patch("neon_llm_core.utils.personas.provider.send_mq_request")
+    @patch("neon_llm_core.utils.personas.state.LLMBot")
+    def test_fetch_persona_config_success(self, mock_bot, mock_send_mq_request):
+        mock_persona_data = [
+            PersonaFactory.create_mock_llm_persona(enabled=True).model_dump(),
+            PersonaFactory.create_mock_llm_persona(enabled=False).model_dump(),
+        ]
+        mock_send_mq_request.return_value = {"items": mock_persona_data}
+        self.provider._fetch_persona_config()
+
+        self.assertEqual(len(self.provider.personas), 1)
+        self.assertEqual(self.provider.personas[0].name, mock_persona_data[0]["name"])
+
+    @patch("neon_llm_core.utils.personas.provider.send_mq_request")
+    @patch("neon_llm_core.utils.personas.state.LLMBot")
+    def test_fetch_persona_config_empty(self, mock_bot, mock_send_mq_request):
+        mock_send_mq_request.return_value = {"items": []}
+        self.provider._fetch_persona_config()
+
+        self.assertEqual(len(self.provider.personas), 0)
+
+    def test__validate_persona_data_success(self):
+        persona_data = PersonaFactory.create_mock_llm_persona().model_dump()
+        persona = self.provider._validate_persona_data(persona_data)
+
+        self.assertIsNotNone(persona)
+        self.assertEqual(persona.name, persona_data['name'])
+
+    def test__validate_persona_data_failure(self):
+        persona_data = {}
+        persona = self.provider._validate_persona_data(persona_data)
+
+        self.assertIsNone(persona)
+
+    @patch.object(PersonaHandlersState, "add_persona_handler")
+    def test_apply_incoming_persona_success(self, mock_add_persona_handler):
+        mock_add_persona_handler.return_value = True
+        persona = Mock(id="mock_persona")
+
+        result = self.provider.apply_incoming_persona(persona)
+
+        self.assertTrue(result)
+        mock_add_persona_handler.assert_called_once_with(persona=persona)
+
+    @patch("neon_llm_core.utils.personas.state.LLMBot")
+    def test_apply_incoming_persona_when_default_personas_are_running(self, mock_llm_bot):
+        persona = PersonaFactory.create_mock_llm_persona(enabled=True)
+
+        self.provider._persona_handlers_state.init_default_personas()
+        self.assertEqual(self.provider._persona_handlers_state.connected_persona_ids,
+                         [persona.id for persona in self.mock_config['llm_bots'][self.mock_service_name]])
+
+        result = self.provider.apply_incoming_persona(persona)
+        self.assertTrue(result)
+
+        # Defaults personas eliminated
+        self.assertEqual(self.provider._persona_handlers_state.connected_persona_ids,
+                         [persona.id])
+
+    @patch("neon_llm_core.utils.personas.state.LLMBot")
+    def test_apply_disabled_incoming_persona_when_default_personas_are_running(self, mock_llm_bot):
+        persona = PersonaFactory.create_mock_llm_persona(enabled=False)
+
+        self.provider._persona_handlers_state.init_default_personas()
+        self.assertEqual(self.provider._persona_handlers_state.connected_persona_ids,
+                         [persona.id for persona in self.mock_config['llm_bots'][self.mock_service_name]])
+
+        result = self.provider.apply_incoming_persona(persona)
+        self.assertFalse(result)
+
+        # Defaults personas stay as is
+        self.assertEqual(self.provider._persona_handlers_state.connected_persona_ids,
+                         [persona.id for persona in self.mock_config['llm_bots'][self.mock_service_name]])
+
+    @patch("neon_llm_core.utils.personas.state.LLMBot")
+    def test_disable_latest_persona_should_activate_default_personas(self, mock_llm_bot):
+        persona = PersonaFactory.create_mock_llm_persona(enabled=True)
+
+        self.provider.apply_incoming_persona(persona)
+
+        # Persona is connected
+        self.assertEqual(self.provider._persona_handlers_state.connected_persona_ids,
+                         [persona.id])
+
+        persona.enabled = False
+
+        self.provider.apply_incoming_persona(persona)
+
+        # Persona is disconnected and default personas are initialised
+        self.assertEqual(self.provider._persona_handlers_state.connected_persona_ids,
+                         [persona.id for persona in self.mock_config['llm_bots'][self.mock_service_name]])
+
+    def test_should_reset_personas_when_no_data(self):
+        result = self.provider._should_reset_personas([])
+        self.assertTrue(result)
+
+    def test_should_not_reset_personas_with_data_and_no_sync_interval(self):
+        self.provider.PERSONA_SYNC_INTERVAL = 0
+        result = self.provider._should_reset_personas([MagicMock()])
+        self.assertFalse(result)

--- a/tests/test_utils/test_state.py
+++ b/tests/test_utils/test_state.py
@@ -1,0 +1,103 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 NeonGecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from neon_llm_core.utils.personas.state import PersonaHandlersState
+from .utils.factory import PersonaFactory
+
+
+class TestPersonaHandlersState(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_service_name = "test_service"
+        self.mock_config = {
+            "llm_bots": {
+                self.mock_service_name: [PersonaFactory.create_mock_llm_persona(enabled=True) for _ in range(5)]
+            },
+            "MQ": {"users": {"neon_llm_submind": {"user": "test", "password": "test"}}}
+        }
+        self.persona_handlers_state = PersonaHandlersState(
+            service_name=self.mock_service_name,
+            ovos_config=self.mock_config
+        )
+
+    def test_initialization(self):
+        self.assertEqual(self.persona_handlers_state.service_name, self.mock_service_name)
+        self.assertEqual(self.persona_handlers_state.ovos_config, self.mock_config)
+        self.assertFalse(self.persona_handlers_state.default_personas_running)
+        self.assertDictEqual(self.persona_handlers_state._created_items, {})
+
+    def test_default_personas(self):
+        self.assertEqual(
+            self.persona_handlers_state.default_personas,
+            self.mock_config["llm_bots"][self.mock_service_name]
+        )
+
+    def test_has_connected_personas(self):
+        self.assertFalse(self.persona_handlers_state.has_connected_personas())
+        self.persona_handlers_state._created_items["persona_1"] = MagicMock()
+        self.assertTrue(self.persona_handlers_state.has_connected_personas())
+
+    @patch("neon_llm_core.utils.personas.state.LLMBot")
+    def test_init_default_personas(self, mock_bot):
+        self.persona_handlers_state.init_default_personas()
+        self.assertTrue(self.persona_handlers_state.default_personas_running)
+
+    @patch("neon_llm_core.utils.personas.state.LLMBot")
+    @patch("neon_data_models.models.LLMPersona", new_callable=PersonaFactory.create_mock_llm_persona, enabled=True)
+    def test_add_persona_handler(self, mock_persona, mock_bot):
+        result = self.persona_handlers_state.add_persona_handler(mock_persona)
+        self.assertIn(mock_persona.id, self.persona_handlers_state._created_items)
+        self.assertEqual(result, mock_bot())
+
+    def test_clean_up_all_personas(self):
+        mock_personas = [PersonaFactory.create_mock_llm_persona(enabled=True) for _ in range(5)]
+        self.persona_handlers_state._created_items = {mock_persona.id: MagicMock()
+                                                      for mock_persona in mock_personas}
+        self.persona_handlers_state.clean_up_personas()
+
+        self.assertEqual(len(self.persona_handlers_state._created_items), 0)
+
+    def test_clean_up_personas_keeps_specified_item(self):
+        mock_personas = [PersonaFactory.create_mock_llm_persona(enabled=True) for _ in range(5)]
+        self.persona_handlers_state._created_items = {mock_persona.id: MagicMock()
+                                                      for mock_persona in mock_personas}
+
+        persona_to_keep = mock_personas[0]
+        self.persona_handlers_state.clean_up_personas(ignore_items=[persona_to_keep])
+
+        self.assertEqual(len(self.persona_handlers_state._created_items), 1)
+        self.assertTrue(persona_to_keep.id in self.persona_handlers_state._created_items)
+
+    def test_remove_persona(self):
+        mock_item = MagicMock()
+        self.persona_handlers_state._created_items = {"persona_1": mock_item}
+        self.persona_handlers_state.remove_persona("persona_1")
+        mock_item.stop.assert_called_once()
+        self.assertNotIn("persona_1", self.persona_handlers_state._created_items)
+

--- a/tests/test_utils/test_state.py
+++ b/tests/test_utils/test_state.py
@@ -100,4 +100,3 @@ class TestPersonaHandlersState(unittest.TestCase):
         self.persona_handlers_state.remove_persona("persona_1")
         mock_item.stop.assert_called_once()
         self.assertNotIn("persona_1", self.persona_handlers_state._created_items)
-

--- a/tests/test_utils/utils/__init__.py
+++ b/tests/test_utils/utils/__init__.py
@@ -1,0 +1,25 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 NeonGecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/test_utils/utils/factory.py
+++ b/tests/test_utils/utils/factory.py
@@ -26,7 +26,7 @@
 
 import uuid
 
-from neon_data_models.models import LLMPersona
+from neon_data_models.models import LLMPersona, LLMPersonaIdentity
 
 
 class PersonaFactory:
@@ -43,4 +43,11 @@ class PersonaFactory:
             description=f"Mock Persona {cls._random_uuid_hex()}",
             system_prompt=f"Mock Prompt: {cls._random_uuid_hex()}",
             enabled=enabled,
+        )
+
+    @classmethod
+    def create_mock_persona_identity(cls):
+        return LLMPersonaIdentity(
+            name=f"mock_persona_identity_{cls._random_uuid_hex()}",
+            user_id=None,
         )

--- a/tests/test_utils/utils/factory.py
+++ b/tests/test_utils/utils/factory.py
@@ -1,3 +1,29 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2025 NeonGecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import uuid
 
 from neon_data_models.models import LLMPersona

--- a/tests/test_utils/utils/factory.py
+++ b/tests/test_utils/utils/factory.py
@@ -1,0 +1,20 @@
+import uuid
+
+from neon_data_models.models import LLMPersona
+
+
+class PersonaFactory:
+
+    @staticmethod
+    def _random_uuid_hex() -> str:
+        return uuid.uuid4().hex
+
+    @classmethod
+    def create_mock_llm_persona(cls, enabled: bool = False):
+        return LLMPersona(
+            name=f"mock_persona_{cls._random_uuid_hex()}",
+            user_id=None,
+            description=f"Mock Persona {cls._random_uuid_hex()}",
+            system_prompt=f"Mock Prompt: {cls._random_uuid_hex()}",
+            enabled=enabled,
+        )


### PR DESCRIPTION
# Description
Adds docstrings and type annotations to persona-related modules
Adds handler for `<name>_personas_input` queue to manage updates from Klat
Modifies default behavior to not periodically sync with the database (all relevant changes will be handled individually)

# Issues
Closes #8 
Implements https://github.com/NeonGeckoCom/pyklatchat/pull/107

# Other Notes
This does not currently account for multiple concurrent updates. One possible solution is to include a timestamp with emitted changes and discard any messages containing changes that are older than what was most recently applied.