### PR TITLE
Update PersonasProvider to use default personas when none are configured

### DIFF
--- a/neon_llm_core/utils/personas/provider.py
+++ b/neon_llm_core/utils/personas/provider.py
@@ -70,6 +70,9 @@ class PersonasProvider:
             LOG.warning(f'Persona state TTL expired, resetting personas config')
             self._personas = []
             self._persona_handlers_state.init_default_handlers()
+        elif not data:
+            self._persona_handlers_state.init_default_handlers()
+            return
         else:
             self._personas = data
         self._persona_handlers_state.clean_up_personas(ignore_items=self._personas)


### PR DESCRIPTION
# Description
Updates persona init to prevent loading an LLM with no personas, making the LLM inaccessible in Klat

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This is an imperfect patch; persona management in general needs a better spec for how to manage:
- user-defined personas
- deployment-defined (default?) personas
- llm-defined specific personas (i.e. BrainForge LLMs)