### PR TITLE
Raise an exception if MQ is not connected during connector startup

### DIFF
--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -241,6 +241,8 @@ class NeonLLMMQConnector(MQConnector, ABC):
                     run_sync=run_sync,
                     run_observer=run_observer,
                     **kwargs)
+        if not self.started:
+            raise RuntimeError(f'Failed to connect to MQ. config={self.config}')
         self._personas_provider.start_sync()
 
     def stop(self):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 # networking
-neon-mq-connector>=0.7.2a9
+neon-mq-connector>=0.7.2a17
 neon_utils[sentry]~=1.12
 ovos-config~=0.0,>=0.0.10
 pydantic~=2.6


### PR DESCRIPTION
# Description
Adds a check for MQ server connection at runtime and raises an exception to exit upon error

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->