### PR TITLE
Default disable sync thread and update obsserver thread behavior

### DIFF
--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -279,12 +279,10 @@ class NeonLLMMQConnector(MQConnector, ABC):
         """
         pass
 
-    def run(self, run_consumers: bool = True, run_sync: bool = True,
-            run_observer: bool = True, **kwargs):
-        super().run(run_consumers=run_consumers,
-                    run_sync=run_sync,
-                    run_observer=run_observer,
-                    **kwargs)
+    def run(self, run_consumers: bool = True, run_sync: bool = False,
+            run_observer: Optional[bool] = None, **kwargs):
+        MQConnector.run(self, run_consumers=run_consumers, run_sync=run_sync,
+                        run_observer=run_observer, **kwargs)
         if not self.started:
             raise RuntimeError(f'Failed to connect to MQ. config={self.config}')
         self._personas_provider.start_sync()


### PR DESCRIPTION
# Description
Update `run_observer` to match mq connector default
Update `run_sync` to `False` to match current LLM implementations

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Current LLM modules appear to disable `sync` already (vllm, chatgpt)
MQ connector now determines observer default based on blocking vs async connector instances