### PR TITLE
Handle voting exceptions to prevent more errors in handlers

### DIFF
--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -149,7 +149,7 @@ class LLMBot(ChatBot):
         response_queue = f"{queue}.response.{uuid4().hex}"
         try:
             LOG.info(f"Sending to {self.mq_queue_config.vhost}/{queue} for "
-                     f"persona={self.persona}")
+                     f"persona={self.persona.name}|response_q={response_queue}")
 
             request_data = LLMProposeRequest(model=self.base_llm,
                                              persona=self.persona,
@@ -182,7 +182,7 @@ class LLMBot(ChatBot):
 
         try:
             LOG.info(f"Sending to {self.mq_queue_config.vhost}/{queue} for "
-                     f"persona={self.persona}")
+                     f"persona={self.persona.name}|response_q={response_queue}")
 
             request_data = LLMDiscussRequest(model=self.base_llm,
                                              persona=self.persona,
@@ -215,8 +215,8 @@ class LLMBot(ChatBot):
         response_queue = f"{queue}.response.{uuid4().hex}"
 
         try:
-            LOG.debug(f"Sending to {self.mq_queue_config.vhost}/{queue} for "
-                      f"persona={self.persona}")
+            LOG.info(f"Sending to {self.mq_queue_config.vhost}/{queue} for "
+                     f"persona={self.persona.name}|response_q={response_queue}")
 
             request_data = LLMVoteRequest(model=self.base_llm,
                                           persona=self.persona,

--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -236,6 +236,9 @@ class NeonLLMMQConnector(MQConnector, ABC):
             except ValueError as err:
                 LOG.error(f'ValueError={err}')
                 sorted_answer_idx = []
+            except Exception as e:
+                LOG.exception(e)
+                sorted_answer_idx = []
 
         api_response = LLMVoteResponse(message_id=message_id,
                                        routing_key=routing_key,


### PR DESCRIPTION
# Description
Add exception handling in scoring to prevent timeouts in vote requests

# Issues
https://neon-ai.sentry.io/issues/6315928472/events/38cf65389abb491c845a036e20a59cfb/
https://neon-ai.sentry.io/issues/6289690855/events/b250bed069204b3f8d4c11771fb365f2/
https://neon-ai.sentry.io/issues/6289690835/events/8da596c296e14089ab2ad9883d8b4f78/
https://neon-ai.sentry.io/issues/6286164166/events/57563deefbf848e7ab5f1e042bb232ae/
https://neon-ai.sentry.io/issues/6292662646/events/ba47ee77f32744d0ba389c9640379661/
https://neon-ai.sentry.io/issues/6316528563/events/71562b2f4a1c4ad1976e253be1661285/

# Other Notes
Deployed with ChatGPT in the Alpha namespace