### PR TITLE
Update logging so Sentry only logs once instead of 3x for voting errors

### DIFF
--- a/neon_llm_core/chatbot.py
+++ b/neon_llm_core/chatbot.py
@@ -128,7 +128,7 @@ class LLMBot(ChatBot):
                                                    responses=bot_responses)
             LOG.info(f'Received answer_data={answer_data}')
             if not answer_data:
-                LOG.error("No response to vote request")
+                LOG.warning("No response to vote request")
                 return DEFAULT_VOTE
             if len(answer_data.sorted_answer_indexes) != len(bots):
                 LOG.error(f"Invalid vote response! "
@@ -161,8 +161,8 @@ class LLMBot(ChatBot):
                                         target_queue=queue,
                                         response_queue=response_queue)
             if not resp_data:
-                LOG.error(f"Timed out waiting for response on "
-                          f"{response_queue}")
+                LOG.warning(f"Timed out waiting for response on "
+                            f"{response_queue}")
                 return None
             LOG.info(f"Got response for persona={self.persona}")
             return LLMProposeResponse.model_validate(obj=resp_data)
@@ -195,8 +195,8 @@ class LLMBot(ChatBot):
                                         target_queue=queue,
                                         response_queue=response_queue)
             if not resp_data:
-                LOG.error(f"Timed out waiting for response on "
-                          f"{response_queue}")
+                LOG.warning(f"Timed out waiting for response on "
+                            f"{response_queue}")
                 return None
             return LLMDiscussResponse.model_validate(obj=resp_data)
         except Exception as e:
@@ -229,8 +229,8 @@ class LLMBot(ChatBot):
                                         target_queue=queue,
                                         response_queue=response_queue)
             if not resp_data:
-                LOG.error(f"Timed out waiting for response on "
-                          f"{response_queue}")
+                LOG.warning(f"Timed out waiting for response on "
+                            f"{response_queue}")
                 return None
             return LLMVoteResponse.model_validate(obj=resp_data)
         except Exception as e:


### PR DESCRIPTION
# Description
Currently, a missing response generates error logs in the MQ connector, in the `_get_llm_api_x` method, and `ask_appraiser`. This downgrades logs to `warning`, so one error only generates one event in Sentry.

# Issues
Single error in alpha generated 3 Sentry errors:
https://neon-ai.sentry.io/issues/6289690835/events/2676729d3d6b45928fd32915cd180ce2/
https://neon-ai.sentry.io/issues/6289690855/events/96478f0505bb4726b70db2d87ed08b4d/
https://neon-ai.sentry.io/issues/6315928472/events/2a76f4261c934b1785b7bf9d97a9d7c2/
https://neon-ai.sentry.io/issues/6289690835/events/a02f0e24069148a29fba60df2c2bec4c/

Sincle error in beta generated 3 Sentry errors:
https://neon-ai.sentry.io/issues/6292662646/events/c66f94bc69634b8fbdf37c6219725575/
https://neon-ai.sentry.io/issues/6316528563/events/b40d424c8bff4fae9e535c6f16d40c6f/
https://neon-ai.sentry.io/issues/6286164166/events/f1154a98237148d49e4f9b4d3fe7f862/

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->