### PR TITLE
Handle model exceptions with default responses

### DIFF
--- a/neon_llm_core/rmq.py
+++ b/neon_llm_core/rmq.py
@@ -200,13 +200,16 @@ class NeonLLMMQConnector(MQConnector, ABC):
         history = request["history"]
         persona = request.get("persona", {})
         LOG.debug(f"Request persona={persona}|key={routing_key}")
+        # Default response if the model fails to respond
+        response = 'Sorry, but I cannot respond to your message at the '\
+                   'moment; please, try again later'
         try:
             response = self.model.ask(message=query, chat_history=history,
                                       persona=persona)
         except ValueError as err:
             LOG.error(f'ValueError={err}')
-            response = ('Sorry, but I cannot respond to your message at the '
-                        'moment, please try again later')
+        except Exception as e:
+            LOG.exception(e)
         api_response = LLMProposeResponse(message_id=message_id,
                                           response=response,
                                           routing_key=routing_key)


### PR DESCRIPTION
# Description
Handle `propose` timeouts the same as `discuss` and `vote` by ensuring a default response is returned in any error case

# Issues
https://neon-ai.sentry.io/issues/6329886374/events/8fe379bc32ed45f3a98548234d96bae5/
https://neon-ai.sentry.io/issues/6330027698/events/95a445983c0e4e3ca851c5db0a1c06ac/
https://neon-ai.sentry.io/issues/6329887389/events/fb15fad3d7ae49ce88e745b5ea2ab3c8/

# Other Notes
Deployed with vLLM to alpha