### PR TITLE
Refactor RMQ tests to use shared fixture

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(neon-llm-core|tqdm|RapidFuzz|typing_extensions).*'
+      packages-exclude: '^(neon-llm-core|tqdm|RapidFuzz|typing_extensions|urllib3).*'

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(neon-llm-core|tqdm).*'
+      packages-exclude: '^(neon-llm-core|tqdm|RapidFuzz|typing_extensions).*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,132 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# IDE Settings
 .vscode
-__pycache__
-dist

--- a/neon_llm_core/utils/personas/models.py
+++ b/neon_llm_core/utils/personas/models.py
@@ -25,4 +25,5 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from neon_data_models.models.api.llm import LLMPersona as PersonaModel
-# TODO: Mark for deprecation
+from ovos_utils.log import log_deprecation
+log_deprecation("Import from `neon_data_models.models.api.llm` directly", "1.0.0")

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-rabbitmq
+neon-minerva[rmq]~=0.0,>=0.2.1a3

--- a/tests/test_rmq.py
+++ b/tests/test_rmq.py
@@ -32,9 +32,8 @@ from unittest.mock import Mock
 from mirakuru import ProcessExitedWithError
 from neon_mq_connector.consumers import SelectConsumerThread
 from neon_mq_connector.utils.network_utils import dict_to_b64
-from port_for import get_port
 from pytest_rabbitmq.factories.executor import RabbitMqExecutor
-from pytest_rabbitmq.factories.process import get_config
+from neon_minerva.integration.rabbit_mq import rmq_instance
 
 from neon_llm_core.llm import NeonLLM
 from neon_llm_core.rmq import NeonLLMMQConnector
@@ -67,53 +66,6 @@ class NeonMockLlm(NeonLLMMQConnector):
                                question: str,
                                answer: str) -> str:
         return self._compose_opinion_prompt(respondent_nick, question, answer)
-
-
-@pytest.fixture(scope="class")
-def rmq_instance(request, tmp_path_factory):
-    config = get_config(request)
-    rabbit_ctl = config["ctl"]
-    rabbit_server = config["server"]
-    rabbit_host = "127.0.0.1"
-    rabbit_port = get_port(config["port"])
-    rabbit_distribution_port = get_port(
-        config["distribution_port"], [rabbit_port]
-    )
-    assert rabbit_distribution_port
-    assert (
-            rabbit_distribution_port != rabbit_port
-    ), "rabbit_port and distribution_port can not be the same!"
-
-    tmpdir = tmp_path_factory.mktemp(f"pytest-rabbitmq-{request.fixturename}")
-
-    rabbit_plugin_path = config["plugindir"]
-
-    rabbit_logpath = config["logsdir"]
-
-    if not rabbit_logpath:
-        rabbit_logpath = tmpdir / "logs"
-
-    rabbit_executor = RabbitMqExecutor(
-        rabbit_server,
-        rabbit_host,
-        rabbit_port,
-        rabbit_distribution_port,
-        rabbit_ctl,
-        logpath=rabbit_logpath,
-        path=tmpdir,
-        plugin_path=rabbit_plugin_path,
-        node_name=config["node"],
-    )
-
-    rabbit_executor.start()
-
-    # Init RMQ config
-    rabbit_executor.rabbitctl_output("add_user", "test_llm_user",
-                                     "test_llm_password")
-    rabbit_executor.rabbitctl_output("add_vhost", "/llm")
-    rabbit_executor.rabbitctl_output("set_permissions", "-p", "/llm",
-                                     "test_llm_user", ".*", ".*", ".*")
-    request.cls.rmq_instance = rabbit_executor
 
 
 @pytest.mark.usefixtures("rmq_instance")


### PR DESCRIPTION
# Description
Update `test_rmq` and test requirements to use shared RMQ fixture
Add deprecation log to address TODO
Update .gitignore to Python template
Update license tests to address errors

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->